### PR TITLE
Updated Auto publishing of Docs and the coverage build link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,6 @@ ifdef::env-github,env-browser[:relfileprefix: docs/]
 https://travis-ci.org/CS2103JAN2018-W14-B1/main[https://travis-ci.org/CS2103JAN2018-W14-B1/main.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
 https://coveralls.io/github/CS2103JAN2018-W14-B1/main?branch=master[image:https://coveralls.io/repos/github/CS2103JAN2018-W14-B1/main/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]
 
 ifdef::env-github[]

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Address Book (Level 4)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/CS2103JAN2018-W14-B1/main[https://travis-ci.org/CS2103JAN2018-W14-B1/main.svg?branch=master[Build Status]]
+https://travis-ci.org/CS2103JAN2018-W14-B1/main[image:https://travis-ci.org/CS2103JAN2018-W14-B1/main.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
 https://coveralls.io/github/CS2103JAN2018-W14-B1/main?branch=master[image:https://coveralls.io/repos/github/CS2103JAN2018-W14-B1/main/badge.svg?branch=master[Coverage Status]]
 https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]


### PR DESCRIPTION
Update the Auto publishing of Docs as stated on the website and also updated the Travis coverage link which was previously being showed on the addressbook